### PR TITLE
Dataset name updates for skim v2

### DIFF
--- a/config/HH_bbWW/Run3_2022EE/samples.yaml
+++ b/config/HH_bbWW/Run3_2022EE/samples.yaml
@@ -5,8 +5,8 @@ GLOBAL:
     - keep ^TT.*
     - keep ^ST.*
     - keep ^GluGlutoRadiontoHHto2B2Vto2B2L2Nu.*
-    - keep DYto2L_M-10to50_amcatnloFXFX
-    - keep DYto2L_M-50_amcatnloFXFX
+    - keep DYto2L_M_10to50_amcatnloFXFX
+    - keep DYto2L_M_50_amcatnloFXFX
     - keep WtoLNu_amcatnloFXFX
     - keep WW
     - keep WZ

--- a/config/HH_bbWW/Run3_2022EE/samples.yaml
+++ b/config/HH_bbWW/Run3_2022EE/samples.yaml
@@ -1,531 +1,553 @@
+GLOBAL:
+  triggerFile: config/HH_bbWW/Run3_2022EE/triggers.yaml
+  sampleSelection:
+    - drop ^.*
+    - keep ^TT.*
+    - keep ^ST.*
+    - keep ^GluGlutoRadiontoHHto2B2Vto2B2L2Nu.*
+    - keep DYto2L_M-10to50_amcatnloFXFX
+    - keep DYto2L_M-50_amcatnloFXFX
+    - keep WtoLNu_amcatnloFXFX
+    - keep WW
+    - keep WZ
+    - keep ZZ
+    - keep ^EGamma_.*
+    - keep ^Muon_.*
+    - keep ^DoubleMuon_.*
+    - keep ^SingleMuon_.*
+    - keep ^MuonEG_.*
+  use_stitching: false
+
+
+
 ############## Start Resonant Signal samples)##############
 ############## Signals(SL,S=0)##############
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-250:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_250:
   sampleType: GluGluToRadion
   mass: 250
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-260:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_260:
   sampleType: GluGluToRadion
   mass: 260
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-270:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_270:
   sampleType: GluGluToRadion
   mass: 270
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-280:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_280:
   sampleType: GluGluToRadion
   mass: 280
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-300:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_300:
   sampleType: GluGluToRadion
   mass: 300
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-350:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_350:
   sampleType: GluGluToRadion
   mass: 350
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-450:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_450:
   sampleType: GluGluToRadion
   mass: 450
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-550:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_550:
   sampleType: GluGluToRadion
   mass: 550
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-600:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_600:
   sampleType: GluGluToRadion
   mass: 600
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-650:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_650:
   sampleType: GluGluToRadion
   mass: 650
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-700:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_700:
   sampleType: GluGluToRadion
   mass: 700
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-800:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_800:
   sampleType: GluGluToRadion
   mass: 800
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-1000:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_1000:
   sampleType: GluGluToRadion
   mass: 1000
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-1200:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_1200:
   sampleType: GluGluToRadion
   mass: 1200
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-1400:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_1400:
   sampleType: GluGluToRadion
   mass: 1400
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-1600:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_1600:
   sampleType: GluGluToRadion
   mass: 1600
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-1800:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_1800:
   sampleType: GluGluToRadion
   mass: 1800
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-2000:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_2000:
   sampleType: GluGluToRadion
   mass: 2000
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-2500:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_2500:
   sampleType: GluGluToRadion
   mass: 2500
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-3000:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_3000:
   sampleType: GluGluToRadion
   mass: 3000
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-4000:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_4000:
   sampleType: GluGluToRadion
   mass: 4000
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2JLNu_M-5000:
+GluGlutoRadiontoHHto2B2Vto2B2JLNu_M_5000:
   sampleType: GluGluToRadion
   mass: 5000
   spin: 0
   crossSection: 1pb
   generator: madgraph
 ############## Signals(SL,S=2)##############
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-250:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_250:
   sampleType: GluGluToBulkGraviton
   mass: 250
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-260:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_260:
   sampleType: GluGluToBulkGraviton
   mass: 260
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-270:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_270:
   sampleType: GluGluToBulkGraviton
   mass: 270
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-280:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_280:
   sampleType: GluGluToBulkGraviton
   mass: 280
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-300:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_300:
   sampleType: GluGluToBulkGraviton
   mass: 300
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-350:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_350:
   sampleType: GluGluToBulkGraviton
   mass: 350
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-450:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_450:
   sampleType: GluGluToBulkGraviton
   mass: 450
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-550:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_550:
   sampleType: GluGluToBulkGraviton
   mass: 550
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-600:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_600:
   sampleType: GluGluToBulkGraviton
   mass: 600
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-650:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_650:
   sampleType: GluGluToBulkGraviton
   mass: 650
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-700:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_700:
   sampleType: GluGluToBulkGraviton
   mass: 700
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-800:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_800:
   sampleType: GluGluToBulkGraviton
   mass: 800
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-1000:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_1000:
   sampleType: GluGluToBulkGraviton
   mass: 1000
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-1200:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_1200:
   sampleType: GluGluToBulkGraviton
   mass: 1200
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-1400:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_1400:
   sampleType: GluGluToBulkGraviton
   mass: 1400
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-1600:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_1600:
   sampleType: GluGluToBulkGraviton
   mass: 1600
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-1800:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_1800:
   sampleType: GluGluToBulkGraviton
   mass: 1800
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-2000:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_2000:
   sampleType: GluGluToBulkGraviton
   mass: 2000
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-2500:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_2500:
   sampleType: GluGluToBulkGraviton
   mass: 2500
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-3000:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_3000:
   sampleType: GluGluToBulkGraviton
   mass: 3000
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-4000:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_4000:
   sampleType: GluGluToBulkGraviton
   mass: 4000
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M-5000:
+GluGlutoBulkGravitontoHHto2B2Vto2B2JLNu_M_5000:
   sampleType: GluGluToBulkGraviton
   mass: 5000
   spin: 2
   crossSection: 1pb
   generator: madgraph
 ############## Signals(DL,S=0)##############
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-250:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_250:
   sampleType: GluGluToRadion
   mass: 250
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-260:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_260:
   sampleType: GluGluToRadion
   mass: 260
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-270:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_270:
   sampleType: GluGluToRadion
   mass: 270
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-280:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_280:
   sampleType: GluGluToRadion
   mass: 280
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-300:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_300:
   sampleType: GluGluToRadion
   mass: 300
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-350:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_350:
   sampleType: GluGluToRadion
   mass: 350
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-450:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_450:
   sampleType: GluGluToRadion
   mass: 450
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-550:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_550:
   sampleType: GluGluToRadion
   mass: 550
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-600:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_600:
   sampleType: GluGluToRadion
   mass: 600
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-650:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_650:
   sampleType: GluGluToRadion
   mass: 650
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-700:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_700:
   sampleType: GluGluToRadion
   mass: 700
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-800:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_800:
   sampleType: GluGluToRadion
   mass: 800
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-1000:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_1000:
   sampleType: GluGluToRadion
   mass: 1000
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-1200:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_1200:
   sampleType: GluGluToRadion
   mass: 1200
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-1400:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_1400:
   sampleType: GluGluToRadion
   mass: 1400
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-1600:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_1600:
   sampleType: GluGluToRadion
   mass: 1600
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-1800:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_1800:
   sampleType: GluGluToRadion
   mass: 1800
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-2000:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_2000:
   sampleType: GluGluToRadion
   mass: 2000
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-2500:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_2500:
   sampleType: GluGluToRadion
   mass: 2500
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-3000:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_3000:
   sampleType: GluGluToRadion
   mass: 3000
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-4000:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_4000:
   sampleType: GluGluToRadion
   mass: 4000
   spin: 0
   crossSection: 1pb
   generator: madgraph
-GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M-5000:
+GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_5000:
   sampleType: GluGluToRadion
   mass: 5000
   spin: 0
   crossSection: 1pb
   generator: madgraph
 ############## Signals(DL,S=2)##############
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-250:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_250:
   sampleType: GluGluToBulkGraviton
   mass: 250
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-260:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_260:
   sampleType: GluGluToBulkGraviton
   mass: 260
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-270:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_270:
   sampleType: GluGluToBulkGraviton
   mass: 270
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-280:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_280:
   sampleType: GluGluToBulkGraviton
   mass: 280
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-300:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_300:
   sampleType: GluGluToBulkGraviton
   mass: 300
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-350:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_350:
   sampleType: GluGluToBulkGraviton
   mass: 350
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-450:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_450:
   sampleType: GluGluToBulkGraviton
   mass: 450
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-550:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_550:
   sampleType: GluGluToBulkGraviton
   mass: 550
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-600:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_600:
   sampleType: GluGluToBulkGraviton
   mass: 600
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-650:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_650:
   sampleType: GluGluToBulkGraviton
   mass: 650
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-700:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_700:
   sampleType: GluGluToBulkGraviton
   mass: 700
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-800:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_800:
   sampleType: GluGluToBulkGraviton
   mass: 800
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-1000:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_1000:
   sampleType: GluGluToBulkGraviton
   mass: 1000
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-1200:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_1200:
   sampleType: GluGluToBulkGraviton
   mass: 1200
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-1400:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_1400:
   sampleType: GluGluToBulkGraviton
   mass: 1400
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-1600:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_1600:
   sampleType: GluGluToBulkGraviton
   mass: 1600
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-1800:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_1800:
   sampleType: GluGluToBulkGraviton
   mass: 1800
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-2000:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_2000:
   sampleType: GluGluToBulkGraviton
   mass: 2000
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-2500:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_2500:
   sampleType: GluGluToBulkGraviton
   mass: 2500
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-3000:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_3000:
   sampleType: GluGluToBulkGraviton
   mass: 3000
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-4000:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_4000:
   sampleType: GluGluToBulkGraviton
   mass: 4000
   spin: 2
   crossSection: 1pb
   generator: madgraph
-GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-5000:
+GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M_5000:
   sampleType: GluGluToBulkGraviton
   mass: 5000
   spin: 2
@@ -535,15 +557,15 @@ GluGlutoBulkGravitontoHHto2B2Vto2B2L2Nu_M-5000:
 ############## Start non -Resonant Signal samples)##############
 #cross section twiki https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGHH ###
 #######GGF########
-GluGlutoHHto2B2V_kl-1p00_kt-1p00_c2-0p00:
+GluGlutoHHto2B2V_kl_1p00_kt_1p00_c2_0p00:
   sampleType: HHnonRes
   generator: powheg
   crossSection: 1pb
-GluGlutoHHto2B2Vto2L2Nu_kl-1p00_kt-1p00_c2-0p00:
+GluGlutoHHto2B2Vto2L2Nu_kl_1p00_kt_1p00_c2_0p00:
   sampleType: HHnonRes
   generator: powheg
   crossSection: 1pb
-GluGlutoHHto2B2Vto2L2Nu_kl-2p45_kt-1p00_c2-0p00:
+GluGlutoHHto2B2Vto2L2Nu_kl_2p45_kt_1p00_c2_0p00:
   sampleType: HHnonRes
   generator: powheg
   crossSection: 1pb
@@ -556,35 +578,35 @@ VBFHHto2B2V_CV_1_C2V_1_C3_1:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2V_CV-1p74_C2V-1p37_C3-14p4:
+VBFHHto2B2V_CV_1p74_C2V_1p37_C3_14p4:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2V_CV-m0p012_C2V-0p030_C3-10p2:
+VBFHHto2B2V_CV_m0p012_C2V_0p030_C3_10p2:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2V_CV-m0p758_C2V-1p44_C3-m19p3:
+VBFHHto2B2V_CV_m0p758_C2V_1p44_C3_m19p3:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2V_CV-m0p962_C2V-0p959_C3-m1p43:
+VBFHHto2B2V_CV_m0p962_C2V_0p959_C3_m1p43:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2V_CV-m1p21_C2V-1p94_C3-m0p94:
+VBFHHto2B2V_CV_m1p21_C2V_1p94_C3_m0p94:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2V_CV-m1p60_C2V-2p72_C3-m1p36:
+VBFHHto2B2V_CV_m1p60_C2V_2p72_C3_m1p36:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2V_CV-m2p12_C2V-3p87_C3-m5p96:
+VBFHHto2B2V_CV_m2p12_C2V_3p87_C3_m5p96:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2V_CV-m1p83_C2V-3p57_C3-m3p39:
+VBFHHto2B2V_CV_m1p83_C2V_3p57_C3_m3p39:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
@@ -596,35 +618,35 @@ VBFHHto2B2Vto2L2Nu_CV_1_C2V_1_C3_1:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2Vto2L2Nu_CV-1p74_C2V-1p37_C3-14p4:
+VBFHHto2B2Vto2L2Nu_CV_1p74_C2V_1p37_C3_14p4:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2Vto2L2Nu_CV-m0p012_C2V-0p030_C3-10p2:
+VBFHHto2B2Vto2L2Nu_CV_m0p012_C2V_0p030_C3_10p2:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2Vto2L2Nu_CV-m0p758_C2V-1p44_C3-m19p3:
+VBFHHto2B2Vto2L2Nu_CV_m0p758_C2V_1p44_C3_m19p3:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2Vto2L2Nu_CV-m0p962_C2V-0p959_C3-m1p43:
+VBFHHto2B2Vto2L2Nu_CV_m0p962_C2V_0p959_C3_m1p43:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2Vto2L2Nu_CV-m1p21_C2V-1p94_C3-m0p94:
+VBFHHto2B2Vto2L2Nu_CV_m1p21_C2V_1p94_C3_m0p94:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2Vto2L2Nu_CV-m1p60_C2V-2p72_C3-m1p36:
+VBFHHto2B2Vto2L2Nu_CV_m1p60_C2V_2p72_C3_m1p36:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2Vto2L2Nu_CV-m2p12_C2V-3p87_C3-m5p96:
+VBFHHto2B2Vto2L2Nu_CV_m2p12_C2V_3p87_C3_m5p96:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb
-VBFHHto2B2Vto2L2Nu_CV-m1p83_C2V-3p57_C3-m3p39:
+VBFHHto2B2Vto2L2Nu_CV_m1p83_C2V_3p57_C3_m3p39:
   sampleType: HHnonRes
   generator: madgraph
   crossSection: 1pb

--- a/config/HH_bbtautau/Run3_2022/samples.yaml
+++ b/config/HH_bbtautau/Run3_2022/samples.yaml
@@ -1,380 +1,332 @@
 ############## Signals ##############
-GluGlutoRadiontoHHto2B2Tau_M-250:
+GluGlutoRadiontoHHto2B2Tau_M_250:
   sampleType: GluGluToRadion
   mass: 250
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-260:
+GluGlutoRadiontoHHto2B2Tau_M_260:
   sampleType: GluGluToRadion
   mass: 260
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-270:
+GluGlutoRadiontoHHto2B2Tau_M_270:
   sampleType: GluGluToRadion
   mass: 270
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-280:
+GluGlutoRadiontoHHto2B2Tau_M_280:
   sampleType: GluGluToRadion
   mass: 280
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-300:
+GluGlutoRadiontoHHto2B2Tau_M_300:
   sampleType: GluGluToRadion
   mass: 300
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-350:
+GluGlutoRadiontoHHto2B2Tau_M_350:
   sampleType: GluGluToRadion
   mass: 350
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-450:
+GluGlutoRadiontoHHto2B2Tau_M_450:
   sampleType: GluGluToRadion
   mass: 450
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-550:
+GluGlutoRadiontoHHto2B2Tau_M_550:
   sampleType: GluGluToRadion
   mass: 550
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-600:
+GluGlutoRadiontoHHto2B2Tau_M_600:
   sampleType: GluGluToRadion
   mass: 600
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-650:
+GluGlutoRadiontoHHto2B2Tau_M_650:
   sampleType: GluGluToRadion
   mass: 650
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-700:
+GluGlutoRadiontoHHto2B2Tau_M_700:
   sampleType: GluGluToRadion
   mass: 700
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-800:
+GluGlutoRadiontoHHto2B2Tau_M_800:
   sampleType: GluGluToRadion
   mass: 800
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-1000:
+GluGlutoRadiontoHHto2B2Tau_M_1000:
   sampleType: GluGluToRadion
   mass: 1000
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-1200:
+GluGlutoRadiontoHHto2B2Tau_M_1200:
   sampleType: GluGluToRadion
   mass: 1200
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-1400:
+GluGlutoRadiontoHHto2B2Tau_M_1400:
   sampleType: GluGluToRadion
   mass: 1400
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-1600:
+GluGlutoRadiontoHHto2B2Tau_M_1600:
   sampleType: GluGluToRadion
   mass: 1600
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-1800:
+GluGlutoRadiontoHHto2B2Tau_M_1800:
   sampleType: GluGluToRadion
   mass: 1800
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-2000:
+GluGlutoRadiontoHHto2B2Tau_M_2000:
   sampleType: GluGluToRadion
   mass: 2000
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-2500:
+GluGlutoRadiontoHHto2B2Tau_M_2500:
   sampleType: GluGluToRadion
   mass: 2500
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-3000:
+GluGlutoRadiontoHHto2B2Tau_M_3000:
   sampleType: GluGluToRadion
   mass: 3000
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-4000:
+GluGlutoRadiontoHHto2B2Tau_M_4000:
   sampleType: GluGluToRadion
   mass: 4000
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoRadiontoHHto2B2Tau_M-5000:
+GluGlutoRadiontoHHto2B2Tau_M_5000:
   sampleType: GluGluToRadion
   mass: 5000
   spin: 0
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-250:
+GluGlutoBulkGravitontoHHto2B2Tau_M_250:
   sampleType: GluGluToBulkGraviton
   mass: 250
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-260:
+GluGlutoBulkGravitontoHHto2B2Tau_M_260:
   sampleType: GluGluToBulkGraviton
   mass: 260
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-270:
+GluGlutoBulkGravitontoHHto2B2Tau_M_270:
   sampleType: GluGluToBulkGraviton
   mass: 270
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-280:
+GluGlutoBulkGravitontoHHto2B2Tau_M_280:
   sampleType: GluGluToBulkGraviton
   mass: 280
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-300:
+GluGlutoBulkGravitontoHHto2B2Tau_M_300:
   sampleType: GluGluToBulkGraviton
   mass: 300
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-350:
+GluGlutoBulkGravitontoHHto2B2Tau_M_350:
   sampleType: GluGluToBulkGraviton
   mass: 350
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-450:
+GluGlutoBulkGravitontoHHto2B2Tau_M_450:
   sampleType: GluGluToBulkGraviton
   mass: 450
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-550:
+GluGlutoBulkGravitontoHHto2B2Tau_M_550:
   sampleType: GluGluToBulkGraviton
   mass: 550
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-600:
+GluGlutoBulkGravitontoHHto2B2Tau_M_600:
   sampleType: GluGluToBulkGraviton
   mass: 600
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-650:
+GluGlutoBulkGravitontoHHto2B2Tau_M_650:
   sampleType: GluGluToBulkGraviton
   mass: 650
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-700:
+GluGlutoBulkGravitontoHHto2B2Tau_M_700:
   sampleType: GluGluToBulkGraviton
   mass: 700
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-800:
+GluGlutoBulkGravitontoHHto2B2Tau_M_800:
   sampleType: GluGluToBulkGraviton
   mass: 800
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-1000:
+GluGlutoBulkGravitontoHHto2B2Tau_M_1000:
   sampleType: GluGluToBulkGraviton
   mass: 1000
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-1200:
+GluGlutoBulkGravitontoHHto2B2Tau_M_1200:
   sampleType: GluGluToBulkGraviton
   mass: 1200
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-1400:
+GluGlutoBulkGravitontoHHto2B2Tau_M_1400:
   sampleType: GluGluToBulkGraviton
   mass: 1400
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-1600:
+GluGlutoBulkGravitontoHHto2B2Tau_M_1600:
   sampleType: GluGluToBulkGraviton
   mass: 1600
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-1800:
+GluGlutoBulkGravitontoHHto2B2Tau_M_1800:
   sampleType: GluGluToBulkGraviton
   mass: 1800
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-2000:
+GluGlutoBulkGravitontoHHto2B2Tau_M_2000:
   sampleType: GluGluToBulkGraviton
   mass: 2000
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-2500:
+GluGlutoBulkGravitontoHHto2B2Tau_M_2500:
   sampleType: GluGluToBulkGraviton
   mass: 2500
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-3000:
+GluGlutoBulkGravitontoHHto2B2Tau_M_3000:
   sampleType: GluGluToBulkGraviton
   mass: 3000
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-4000:
+GluGlutoBulkGravitontoHHto2B2Tau_M_4000:
   sampleType: GluGluToBulkGraviton
   mass: 4000
   spin: 2
   generator: madgraph
   crossSection: 1pb
-GluGlutoBulkGravitontoHHto2B2Tau_M-5000:
+GluGlutoBulkGravitontoHHto2B2Tau_M_5000:
   sampleType: GluGluToBulkGraviton
   mass: 5000
   spin: 2
   generator: madgraph
   crossSection: 1pb
 ####################Non-resonant signals###########
-GluGlutoHHto2B2Tau_kl-0p00_kt-1p00_c2-0p00:
+GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_0p00:
   sampleType: HHnonRes
   generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
-GluGlutoHHto2B2Tau_kl-0p00_kt-1p00_c2-1p00:
+GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_1p00:
   sampleType: HHnonRes
   generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
-GluGlutoHHto2B2Tau_kl-1p00_kt-1p00_c2-0p00:
+GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p00:
   sampleType: HHnonRes
   generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
-GluGlutoHHto2B2Tau_kl-1p00_kt-1p00_c2-0p10:
+GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p00_LHEweights:
   sampleType: HHnonRes
   generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
-GluGlutoHHto2B2Tau_kl-1p00_kt-1p00_c2-0p35:
+GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p10:
   sampleType: HHnonRes
   generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
-GluGlutoHHto2B2Tau_kl-1p00_kt-1p00_c2-3p00:
+GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p35:
   sampleType: HHnonRes
   generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
-GluGlutoHHto2B2Tau_kl-1p00_kt-1p00_c2-m2p00:
+GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_3p00:
   sampleType: HHnonRes
   generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
-GluGlutoHHto2B2Tau_kl-2p45_kt-1p00_c2-0p00:
+GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_m2p00:
   sampleType: HHnonRes
   generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
-GluGlutoHHto2B2Tau_kl-5p00_kt-1p00_c2-0p00:
+GluGlutoHHto2B2Tau_kl_2p45_kt_1p00_c2_0p00:
   sampleType: HHnonRes
   generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
-VBFHHto2B2Tau_CV-1_C2V-1_C3-1:
+GluGlutoHHto2B2Tau_kl_2p45_kt_1p00_c2_0p00_LHEweights:
   sampleType: HHnonRes
-  generator: madgraph
+  generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
-VBFHHto2B2Tau_CV-1_C2V-1_C3-2:
+GluGlutoHHto2B2Tau_kl_5p00_kt_1p00_c2_0p00:
   sampleType: HHnonRes
-  generator: madgraph
-  mass: 125
-  spin: 0
-  crossSection: 1pb
-VBFHHto2B2Tau_CV-1_C2V-2_C3-1:
-  sampleType: HHnonRes
-  generator: madgraph
-  mass: 125
-  spin: 0
-  crossSection: 1pb
-VBFHHto2B2Tau_CV-1p74_C2V-1p37_C3-14p4:
-  sampleType: HHnonRes
-  generator: madgraph
-  mass: 125
-  spin: 0
-  crossSection: 1pb
-VBFHHto2B2Tau_CV-m0p012_C2V-0p030_C3-10p2:
-  sampleType: HHnonRes
-  generator: madgraph
-  mass: 125
-  spin: 0
-  crossSection: 1pb
-VBFHHto2B2Tau_CV-m0p758_C2V-1p44_C3-m19p3:
-  sampleType: HHnonRes
-  generator: madgraph
-  mass: 125
-  spin: 0
-  crossSection: 1pb
-VBFHHto2B2Tau_CV-m0p962_C2V-0p959_C3-m1p43:
-  sampleType: HHnonRes
-  generator: madgraph
-  mass: 125
-  spin: 0
-  crossSection: 1pb
-VBFHHto2B2Tau_CV-m1p21_C2V-1p94_C3-m0p94:
-  sampleType: HHnonRes
-  generator: madgraph
-  mass: 125
-  spin: 0
-  crossSection: 1pb
-VBFHHto2B2Tau_CV-m1p60_C2V-2p72_C3-m1p36:
-  sampleType: HHnonRes
-  generator: madgraph
-  mass: 125
-  spin: 0
-  crossSection: 1pb
-VBFHHto2B2Tau_CV-m2p12_C2V-3p87_C3-m5p96:
-  sampleType: HHnonRes
-  generator: madgraph
+  generator: powheg
   mass: 125
   spin: 0
   crossSection: 1pb
@@ -385,6 +337,72 @@ VBFHHto2B2Tau_CV_1_C2V_0_C3_1:
   spin: 0
   crossSection: 1pb
 VBFHHto2B2Tau_CV_1_C2V_1_C3_1:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_1_C2V_1_C3_1_v2:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_1_C2V_1_C3_2:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_1_C2V_2_C3_1:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_1p74_C2V_1p37_C3_14p4:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_m0p012_C2V_0p030_C3_10p2:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_m0p758_C2V_1p44_C3_m19p3:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_m0p962_C2V_0p959_C3_m1p43:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_m1p21_C2V_1p94_C3_m0p94:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_m1p60_C2V_2p72_C3_m1p36:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_m1p83_C2V_3p57_C3_m3p39:
+  sampleType: HHnonRes
+  generator: madgraph
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+VBFHHto2B2Tau_CV_m2p12_C2V_3p87_C3_m5p96:
   sampleType: HHnonRes
   generator: madgraph
   mass: 125

--- a/config/Run3_2022/samples.yaml
+++ b/config/Run3_2022/samples.yaml
@@ -2,9 +2,9 @@ GLOBAL:
   era: Run3_2022
   luminosity: 7980.4 # pb-1
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2024_v1/Run3_2022'
+  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2022'
   nano_version: v14
-  crossSectionsFile : config/crossSections13TeV.yaml
+  crossSectionsFile : config/crossSections13p6TeV.yaml
   use_stitching: false
   met_type: PFMET
 
@@ -42,156 +42,156 @@ JetMET_Run2022D:
 ############## DY ##############
 ############## powheg ##############
 ############## DYto2E ##############
-DYto2E_MLL-10to50_powheg:
+DYto2E_MLL_10to50_powheg:
   crossSectionStitch: DYto2E_MLL-10to50_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2E_MLL-50to120_powheg:
+DYto2E_MLL_50to120_powheg:
   crossSectionStitch: DYto2E_MLL-50to120_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2E_MLL-120to200_powheg:
+DYto2E_MLL_120to200_powheg:
   crossSectionStitch: DYto2E_MLL-120to200_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2E_MLL-200to400_powheg:
+DYto2E_MLL_200to400_powheg:
   crossSectionStitch: DYto2E_MLL-200to400_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2E_MLL-400to800_powheg:
+DYto2E_MLL_400to800_powheg:
   crossSectionStitch: DYto2E_MLL-400to800_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2E_MLL-800to1500_powheg:
+DYto2E_MLL_800to1500_powheg:
   crossSectionStitch: DYto2E_MLL-800to1500_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2E_MLL-1500to2500_powheg:
+DYto2E_MLL_1500to2500_powheg:
   crossSectionStitch: DYto2E_MLL-1500to2500_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2E_MLL-2500to4000_powheg:
+DYto2E_MLL_2500to4000_powheg:
   crossSectionStitch: DYto2E_MLL-2500to4000_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2E_MLL-4000to6000_powheg:
+DYto2E_MLL_4000to6000_powheg:
   crossSectionStitch: DYto2E_MLL-4000to6000_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2E_MLL-6000_powheg:
+DYto2E_MLL_6000_powheg:
   crossSectionStitch: DYto2E_MLL-6000_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
 
 ############## DYto2Mu ##############
-DYto2Mu_MLL-10to50_powheg:
+DYto2Mu_MLL_10to50_powheg:
   crossSectionStitch: DYto2Mu_MLL-10to50_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Mu_MLL-50to120_powheg:
+DYto2Mu_MLL_50to120_powheg:
   crossSectionStitch: DYto2Mu_MLL-50to120_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Mu_MLL-120to200_powheg:
+DYto2Mu_MLL_120to200_powheg:
   crossSectionStitch: DYto2Mu_MLL-120to200_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Mu_MLL-200to400_powheg:
+DYto2Mu_MLL_200to400_powheg:
   crossSectionStitch: DYto2Mu_MLL-200to400_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Mu_MLL-400to800_powheg:
+DYto2Mu_MLL_400to800_powheg:
   crossSectionStitch: DYto2Mu_MLL-400to800_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Mu_MLL-800to1500_powheg:
+DYto2Mu_MLL_800to1500_powheg:
   crossSectionStitch: DYto2Mu_MLL-800to1500_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Mu_MLL-1500to2500_powheg:
+DYto2Mu_MLL_1500to2500_powheg:
   crossSectionStitch: DYto2Mu_MLL-1500to2500_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Mu_MLL-2500to4000_powheg:
+DYto2Mu_MLL_2500to4000_powheg:
   crossSectionStitch: DYto2Mu_MLL-2500to4000_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Mu_MLL-4000to6000_powheg:
+DYto2Mu_MLL_4000to6000_powheg:
   crossSectionStitch: DYto2Mu_MLL-4000to6000_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Mu_MLL-6000_powheg:
+DYto2Mu_MLL_6000_powheg:
   crossSectionStitch: DYto2Mu_MLL-6000_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
 
 ############## DYto2Tau ##############
-DYto2Tau_MLL-10to50_powheg:
+DYto2Tau_MLL_10to50_powheg:
   crossSectionStitch: DYto2Tau_MLL-10to50_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Tau_MLL-50to120_powheg:
+DYto2Tau_MLL_50to120_powheg:
   crossSectionStitch: DYto2Tau_MLL-50to120_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Tau_MLL-120to200_powheg:
+DYto2Tau_MLL_120to200_powheg:
   crossSectionStitch: DYto2Tau_MLL-120to200_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Tau_MLL-200to400_powheg:
+DYto2Tau_MLL_200to400_powheg:
   crossSectionStitch: DYto2Tau_MLL-200to400_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Tau_MLL-400to800_powheg:
+DYto2Tau_MLL_400to800_powheg:
   crossSectionStitch: DYto2Tau_MLL-400to800_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Tau_MLL-800to1500_powheg:
+DYto2Tau_MLL_800to1500_powheg:
   crossSectionStitch: DYto2Tau_MLL-800to1500_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Tau_MLL-1500to2500_powheg:
+DYto2Tau_MLL_1500to2500_powheg:
   crossSectionStitch: DYto2Tau_MLL-1500to2500_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Tau_MLL-2500to4000_powheg:
+DYto2Tau_MLL_2500to4000_powheg:
   crossSectionStitch: DYto2Tau_MLL-2500to4000_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Tau_MLL-4000to6000_powheg:
+DYto2Tau_MLL_4000to6000_powheg:
   crossSectionStitch: DYto2Tau_MLL-4000to6000_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2Tau_MLL-6000_powheg:
+DYto2Tau_MLL_6000_powheg:
   crossSectionStitch: DYto2Tau_MLL-6000_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
@@ -199,133 +199,140 @@ DYto2Tau_MLL-6000_powheg:
 
 ############## amcatnloFXFX ##############
 ############## DYto2L ##############
-DYto2L_M-10to50_amcatnloFXFX:
+DYto2L_M_10to50_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-10to50_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_amcatnloFXFX:
+DYto2L_M_50_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
   isReference: True
   crossSection: DY_NNLO_QCD+NLO_EW
+DYto2L_M_50_amcatnloFXFX_ext1:
+  crossSectionStitch: DYto2L_M-50_amcatnloFXFX
+  generator: amcatnloFXFX
+  miniAOD: /DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v1/MINIAODSIM
+  sampleType: DY
+  isReference: True
+  crossSection: DY_NNLO_QCD+NLO_EW
 
 ############## DYto2L_M-50_nJ ##############
-DYto2L_M-50_0J_amcatnloFXFX:
+DYto2L_M_50_0J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_0J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_0J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_1J_amcatnloFXFX:
+DYto2L_M_50_1J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_2J_amcatnloFXFX:
+DYto2L_M_50_2J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
 
 
-############## DYto2L_M-*_PTLL ##############
-DYto2L_M-50_PTLL-40to100_1J_amcatnloFXFX:
+############## DYto2L_M_*_PTLL ##############
+DYto2L_M_50_PTLL_40to100_1J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_PTLL-40to100_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-40to100_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_PTLL-40to100_2J_amcatnloFXFX:
+DYto2L_M_50_PTLL_40to100_2J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_PTLL-40to100_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-40to100_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: DY
 
-DYto2L_M-50_PTLL-100to200_1J_amcatnloFXFX:
+DYto2L_M_50_PTLL_100to200_1J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_PTLL-100to200_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-100to200_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_PTLL-100to200_2J_amcatnloFXFX:
+DYto2L_M_50_PTLL_100to200_2J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_PTLL-100to200_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-100to200_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: DY
 
-DYto2L_M-50_PTLL-200to400_1J_amcatnloFXFX:
+DYto2L_M_50_PTLL_200to400_1J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_PTLL-200to400_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-200to400_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_PTLL-200to400_2J_amcatnloFXFX:
+DYto2L_M_50_PTLL_200to400_2J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_PTLL-200to400_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-200to400_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: DY
 
-DYto2L_M-50_PTLL-400to600_1J_amcatnloFXFX:
+DYto2L_M_50_PTLL_400to600_1J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_PTLL-400to600_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-400to600_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_PTLL-400to600_2J_amcatnloFXFX:
+DYto2L_M_50_PTLL_400to600_2J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_PTLL-400to600_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-400to600_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: DY
 
 
-DYto2L_M-50_PTLL-600_1J_amcatnloFXFX:
+DYto2L_M_50_PTLL_600_1J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_PTLL-600_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-600_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_PTLL-600_2J_amcatnloFXFX:
+DYto2L_M_50_PTLL_600_2J_amcatnloFXFX:
   crossSectionStitch: DYto2L_M-50_PTLL-600_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-600_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: DY
 
 ############## madgraphMLM ##############
-DYto2L_M-10to50_madgraphMLM:
+DYto2L_M_10to50_madgraphMLM:
   crossSectionStitch: DYto2L_M-10to50_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_madgraphMLM:
+DYto2L_M_50_madgraphMLM:
   crossSectionStitch: DYto2L_M-50_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_madgraphMLM_ext1:
+DYto2L_M_50_madgraphMLM_ext1:
   crossSectionStitch: DYto2L_M-50_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM
   sampleType: DY
 
-DYto2L_M-50_1J_madgraphMLM:
+DYto2L_M_50_1J_madgraphMLM:
   crossSectionStitch: DYto2L_M-50_1J_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_1J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_2J_madgraphMLM:
+DYto2L_M_50_2J_madgraphMLM:
   crossSectionStitch: DYto2L_M-50_2J_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_2J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_3J_madgraphMLM:
+DYto2L_M_50_3J_madgraphMLM:
   crossSectionStitch: DYto2L_M-50_3J_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_3J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
-DYto2L_M-50_4J_madgraphMLM:
+DYto2L_M_50_4J_madgraphMLM:
   crossSectionStitch: DYto2L_M-50_4J_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_4J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: DY
 
-DYto2TautoMuTauh_M-50_madgraphMLM:
+DYto2TautoMuTauh_M_50_madgraphMLM:
   crossSectionStitch: DYto2TautoMuTauh_M-50_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2TautoMuTauh_M-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
@@ -406,99 +413,99 @@ QCD_HT2000toInf_MLM:
   sampleType: QCD
 
 ############## QCD_PT-*_EMEnriched ##############
-QCD_PT-10to30_EMEnriched:
+QCD_PT_10to30_EMEnriched:
   crossSection: QCD_PT-10to30_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-10to30_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-30to50_EMEnriched:
+QCD_PT_30to50_EMEnriched:
   crossSection: QCD_PT-30to50_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-30to50_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-50to80_EMEnriched:
+QCD_PT_50to80_EMEnriched:
   crossSection: QCD_PT-50to80_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-50to80_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-80to120_EMEnriched:
+QCD_PT_80to120_EMEnriched:
   crossSection: QCD_PT-80to120_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-80to120_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-120to170_EMEnriched:
+QCD_PT_120to170_EMEnriched:
   crossSection: QCD_PT-120to170_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-120to170_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-170to300_EMEnriched:
+QCD_PT_170to300_EMEnriched:
   crossSection: QCD_PT-170to300_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-170to300_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-300toInf_EMEnriched:
+QCD_PT_300toInf_EMEnriched:
   crossSection: QCD_PT-300toInf_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-300toInf_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
 
 ############## QCD_PT-*to*_MuEnriched ##############
-QCD_PT-15to20_MuEnrichedPt5:
+QCD_PT_15to20_MuEnrichedPt5:
   crossSection: QCD_PT-15to20_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-15to20_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-20to30_MuEnrichedPt5:
+QCD_PT_20to30_MuEnrichedPt5:
   crossSection: QCD_PT-20to30_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-20to30_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-30to50_MuEnrichedPt5:
+QCD_PT_30to50_MuEnrichedPt5:
   crossSection: QCD_PT-30to50_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-30to50_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-50to80_MuEnrichedPt5:
+QCD_PT_50to80_MuEnrichedPt5:
   crossSection: QCD_PT-50to80_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-50to80_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-80to120_MuEnrichedPt5:
+QCD_PT_80to120_MuEnrichedPt5:
   crossSection: QCD_PT-80to120_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-80to120_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-120to170_MuEnrichedPt5:
+QCD_PT_120to170_MuEnrichedPt5:
   crossSection: QCD_PT-120to170_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-120to170_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-170to300_MuEnrichedPt5:
+QCD_PT_170to300_MuEnrichedPt5:
   crossSection: QCD_PT-170to300_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-170to300_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-300to470_MuEnrichedPt5:
+QCD_PT_300to470_MuEnrichedPt5:
   crossSection: QCD_PT-300to470_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-300to470_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-470to600_MuEnrichedPt5:
+QCD_PT_470to600_MuEnrichedPt5:
   crossSection: QCD_PT-470to600_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-470to600_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-600to800_MuEnrichedPt5:
+QCD_PT_600to800_MuEnrichedPt5:
   crossSection: QCD_PT-600to800_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-600to800_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-800to1000_MuEnrichedPt5:
+QCD_PT_800to1000_MuEnrichedPt5:
   crossSection: QCD_PT-800to1000_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-800to1000_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: QCD
-QCD_PT-1000_MuEnrichedPt5:
+QCD_PT_1000_MuEnrichedPt5:
   crossSection: QCD_PT-1000_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-1000_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
@@ -588,23 +595,23 @@ QCD_PT_3200:
 
 
 ############## ST ##############
-ST_s-channel_antitop_4f_leptonDecays:
+ST_s_channel_antitop_4f_leptonDecays:
   crossSection: ST_s-channel_antitop_LNu
   generator: amcatnlo
   miniAOD: /TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
-ST_s-channel_top_4f_leptonDecays:
+ST_s_channel_top_4f_leptonDecays:
   crossSection: ST_s-channel_top_LNu
   generator: amcatnlo
   miniAOD: /TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
 
-ST_t-channel_antitop_4f_InclusiveDecays:
+ST_t_channel_antitop_4f_InclusiveDecays:
   crossSection: ST_t-channel_antitop
   generator: powheg
   miniAOD: /TbarBQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
-ST_t-channel_top_4f_InclusiveDecays:
+ST_t_channel_top_4f_InclusiveDecays:
   crossSection: ST_t-channel_top
   generator: powheg
   miniAOD: /TBbarQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
@@ -764,12 +771,12 @@ VBFHToWWTo2L2Nu_M125:
   sampleType: H
 
 ############## V ##############
-WToMuNu_M-200:
+WToMuNu_M_200:
   crossSection: WToMuNu_M-200
   generator: pythia8
   miniAOD: /WtoMuNu_M-200_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: W
-WToTauNu_M-200:
+WToTauNu_M_200:
   crossSection: WToTauNu_M-200
   generator: pythia8
   miniAOD: /WtoNuTau_M-200_TuneCP5_13p6TeV_pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
@@ -812,27 +819,27 @@ WtoLNu_4J_madgraphMLM:
   miniAOD: /WtoLNu-4Jets_4J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: W
 
-WtoLNu_MLNu-0to120_HT-40To100_madgraph:
+WtoLNu_MLNu_0to120_HT_40To100_madgraph:
   crossSection: WtoLNu_MLNu-0to120_HT-40To100_madgraph
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_MLNu-0to120_HT-40to100_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v3/MINIAODSIM
   sampleType: W
-WtoLNu_MLNu-0to120_HT-100To400_madgraph:
+WtoLNu_MLNu_0to120_HT_100To400_madgraph:
   crossSection: WtoLNu_MLNu-0to120_HT-100To400_madgraph
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_MLNu-0to120_HT-100to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v3/MINIAODSIM
   sampleType: W
-WtoLNu_MLNu-0to120_HT-400To800_madgraph:
+WtoLNu_MLNu_0to120_HT_400To800_madgraph:
   crossSection: WtoLNu_MLNu-0to120_HT-400To800_madgraph
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_MLNu-0to120_HT-400to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v1/MINIAODSIM
   sampleType: W
-WtoLNu_MLNu-0to120_HT-800To1500_madgraph:
+WtoLNu_MLNu_0to120_HT_800To1500_madgraph:
   crossSection: WtoLNu_MLNu-0to120_HT-800To1500_madgraph
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_MLNu-0to120_HT-800to1500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: W
-WtoLNu_MLNu-0to120_HT-1500To2500_madgraph:
+WtoLNu_MLNu_0to120_HT_1500To2500_madgraph:
   crossSection: WtoLNu_MLNu-0to120_HT-1500To2500_madgraph
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_MLNu-0to120_HT-1500to2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
@@ -1063,53 +1070,53 @@ ZH_Hbb_Zqq_ext1:
   miniAOD: /ZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v3/MINIAODSIM
   sampleType: VH
 
-Zto2Nu_HT-100To200:
+Zto2Nu_HT_100To200:
   crossSection: Zto2Nu_HT-100To200
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: Zto2Nu
-Zto2Nu_HT-200To400:
+Zto2Nu_HT_200To400:
   crossSection: Zto2Nu_HT-200To400
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: Zto2Nu
-Zto2Nu_HT-400To800:
+Zto2Nu_HT_400To800:
   crossSection: Zto2Nu_HT-400To800
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-400to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: Zto2Nu
-Zto2Nu_HT-800To1500:
+Zto2Nu_HT_800To1500:
   crossSection: Zto2Nu_HT-800To1500
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-800to1500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: Zto2Nu
-Zto2Nu_HT-1500To2500:
+Zto2Nu_HT_1500To2500:
   crossSection: Zto2Nu_HT-1500To2500
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-1500to2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: Zto2Nu
-Zto2Nu_HT-2500ToInf:
+Zto2Nu_HT_2500ToInf:
   crossSection: Zto2Nu_HT-2500ToInf
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: Zto2Nu
 
-Zto2Q_HT-200to400:
+Zto2Q_HT_200to400:
   crossSection: Zto2Q_HT-200to400
   generator: madgraphMLM
   miniAOD: /Zto2Q-4Jets_HT-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ZQQ
-Zto2Q_HT-400to600:
+Zto2Q_HT_400to600:
   crossSection: Zto2Q_HT-400to600
   generator: madgraphMLM
   miniAOD: /Zto2Q-4Jets_HT-400to600_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ZQQ
-Zto2Q_HT-600to800:
+Zto2Q_HT_600to800:
   crossSection: Zto2Q_HT-600to800
   generator: madgraphMLM
   miniAOD: /Zto2Q-4Jets_HT-600to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ZQQ
-Zto2Q_HT-800toInf:
+Zto2Q_HT_800toInf:
   crossSection: Zto2Q_HT-800toInf
   generator: madgraphMLM
   miniAOD: /Zto2Q-4Jets_HT-800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM

--- a/config/Run3_2022EE/samples.yaml
+++ b/config/Run3_2022EE/samples.yaml
@@ -2,11 +2,10 @@ GLOBAL:
   era: Run3_2022EE
   luminosity: 26671.7 # pb-1
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2024_v1/Run3_2022EE'
+  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2022EE'
   nano_version: v14
-  crossSectionsFile : config/crossSections13TeV.yaml
-  use_stitching: false
-  met_type: PFMET
+  crossSectionsFile : config/crossSections13p6TeV.yaml
+  triggerFile: config/Run3_2022EE/triggers.yaml
 
 ############## Data ##############
 EGamma_Run2022E:
@@ -42,260 +41,280 @@ JetMET_Run2022G:
 
 
 ############## DY ##############
-DYto2E_MLL-10to50_powheg:
+DYto2E_MLL_10to50_powheg:
   sampleType: DY
   crossSectionStitch: DYto2E_MLL-10to50_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2E_MLL-50to120_powheg:
+DYto2E_MLL_50to120_powheg:
   sampleType: DY
   crossSectionStitch: DYto2E_MLL-50to120_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2E_MLL-120to200_powheg:
+DYto2E_MLL_120to200_powheg:
   sampleType: DY
   crossSectionStitch: DYto2E_MLL-120to200_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2E_MLL-200to400_powheg:
+DYto2E_MLL_200to400_powheg:
   sampleType: DY
   crossSectionStitch: DYto2E_MLL-200to400_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2E_MLL-400to800_powheg:
+DYto2E_MLL_400to800_powheg:
   sampleType: DY
   crossSectionStitch: DYto2E_MLL-400to800_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2E_MLL-800to1500_powheg:
+DYto2E_MLL_800to1500_powheg:
   sampleType: DY
   crossSectionStitch: DYto2E_MLL-800to1500_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2E_MLL-1500to2500_powheg:
+DYto2E_MLL_1500to2500_powheg:
   sampleType: DY
   crossSectionStitch: DYto2E_MLL-1500to2500_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2E_MLL-2500to4000_powheg:
+DYto2E_MLL_2500to4000_powheg:
   sampleType: DY
   crossSectionStitch: DYto2E_MLL-2500to4000_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2E_MLL-4000to6000_powheg:
+DYto2E_MLL_4000to6000_powheg:
   sampleType: DY
   crossSectionStitch: DYto2E_MLL-4000to6000_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2E_MLL-6000_powheg:
+DYto2E_MLL_6000_powheg:
   sampleType: DY
   crossSectionStitch: DYto2E_MLL-6000_powheg
   generator: powheg
   miniAOD: /DYto2E_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2L_M-10to50_amcatnloFXFX:
+DYto2L_M_10to50_amcatnloFXFX:
   sampleType: DY
-  crossSectionStitch: DYto2L_M-10to50_amcatnloFXFX
+  crossSection: DYto2L_M-10to50_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2L_M-10to50_madgraphMLM:
+DYto2L_M_10to50_madgraphMLM:
   sampleType: DY
   crossSectionStitch: DYto2L_M-10to50_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM
-DYto2L_M-50_0J_amcatnloFXFX:
+DYto2L_M_50_0J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_0J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_0J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2L_M-50_1J_amcatnloFXFX:
+DYto2L_M_50_1J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2L_M-50_1J_madgraphMLM:
+DYto2L_M_50_1J_madgraphMLM:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_1J_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_1J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2L_M-50_2J_amcatnloFXFX:
+DYto2L_M_50_2J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2L_M-50_2J_madgraphMLM:
+DYto2L_M_50_2J_madgraphMLM:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_2J_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_2J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2L_M-50_3J_madgraphMLM:
+DYto2L_M_50_3J_madgraphMLM:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_3J_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_3J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2L_M-50_4J_madgraphMLM:
+DYto2L_M_50_4J_madgraphMLM:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_4J_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_4J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2L_M-50_amcatnloFXFX:
+DYto2L_M_50_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
+  isReference: True
+  crossSection: DY_NNLO_QCD+NLO_EW
+DYto2L_M_50_amcatnloFXFX_ext1:
+  sampleType: DY
+  crossSectionStitch: DYto2L_M-50_amcatnloFXFX
+  generator: amcatnloFXFX
+  miniAOD: fill_me
 
-DYto2L_M-50_madgraphMLM:
+
+
+DYto2L_M_50_madgraphMLM:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
   isReference: True
   crossSection: DY_NNLO_QCD+NLO_EW
-DYto2L_M-50_madgraphMLM_ext1:
+DYto2L_M_50_madgraphMLM_ext1:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_madgraphMLM
   generator: madgraphMLM
   miniAOD: /DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM
-DYto2L_M-50_PTLL-40to100_1J_amcatnloFXFX:
+DYto2L_M_50_PTLL_40to100_1J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_PTLL-40to100_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-40to100_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v1/MINIAODSIM
-DYto2L_M-50_PTLL-40to100_2J_amcatnloFXFX:
+DYto2L_M_50_PTLL_40to100_2J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_PTLL-40to100_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-40to100_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM
-DYto2L_M-50_PTLL-100to200_1J_amcatnloFXFX:
+DYto2L_M_50_PTLL_100to200_1J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_PTLL-100to200_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-100to200_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v1/MINIAODSIM
-DYto2L_M-50_PTLL-100to200_2J_amcatnloFXFX:
+DYto2L_M_50_PTLL_100to200_2J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_PTLL-100to200_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-100to200_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM
-DYto2L_M-50_PTLL-200to400_1J_amcatnloFXFX:
+DYto2L_M_50_PTLL_200to400_1J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_PTLL-200to400_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-200to400_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v1/MINIAODSIM
-DYto2L_M-50_PTLL-200to400_2J_amcatnloFXFX:
+DYto2L_M_50_PTLL_200to400_2J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_PTLL-200to400_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-200to400_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM
-DYto2L_M-50_PTLL-400to600_1J_amcatnloFXFX:
+DYto2L_M_50_PTLL_400to600_1J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_PTLL-400to600_1J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-400to600_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v1/MINIAODSIM
-DYto2L_M-50_PTLL-400to600_2J_amcatnloFXFX:
+DYto2L_M_50_PTLL_400to600_2J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_PTLL-400to600_2J_amcatnloFXFX
   generator: amcatnloFXFX
   miniAOD: /DYto2L-2Jets_MLL-50_PTLL-400to600_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Mu_MLL-10to50_powheg:
+DYto2L_M_50_PTLL_600_1J_amcatnloFXFX:
+  sampleType: DY
+  crossSectionStitch: DYto2L_M-50_PTLL-600_1J_amcatnloFXFX
+  generator: amcatnloFXFX
+  miniAOD: fill_me
+DYto2L_M_50_PTLL_600_2J_amcatnloFXFX:
+  sampleType: DY
+  crossSectionStitch: DYto2L_M-50_PTLL-600_2J_amcatnloFXFX
+  generator: amcatnloFXFX
+  miniAOD: fill_me
+
+DYto2Mu_MLL_10to50_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Mu_MLL-10to50_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Mu_MLL-50to120_powheg:
+DYto2Mu_MLL_50to120_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Mu_MLL-50to120_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Mu_MLL-120to200_powheg:
+DYto2Mu_MLL_120to200_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Mu_MLL-120to200_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Mu_MLL-200to400_powheg:
+DYto2Mu_MLL_200to400_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Mu_MLL-200to400_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Mu_MLL-400to800_powheg:
+DYto2Mu_MLL_400to800_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Mu_MLL-400to800_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Mu_MLL-800to1500_powheg:
+DYto2Mu_MLL_800to1500_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Mu_MLL-800to1500_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Mu_MLL-1500to2500_powheg:
+DYto2Mu_MLL_1500to2500_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Mu_MLL-1500to2500_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Mu_MLL-2500to4000_powheg:
+DYto2Mu_MLL_2500to4000_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Mu_MLL-2500to4000_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Mu_MLL-4000to6000_powheg:
+DYto2Mu_MLL_4000to6000_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Mu_MLL-4000to6000_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Mu_MLL-6000_powheg:
+DYto2Mu_MLL_6000_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Mu_MLL-6000_powheg
   generator: powheg
   miniAOD: /DYto2Mu_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Tau_MLL-10to50_powheg:
+DYto2Tau_MLL_10to50_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Tau_MLL-10to50_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Tau_MLL-50to120_powheg:
+DYto2Tau_MLL_50to120_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Tau_MLL-50to120_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Tau_MLL-120to200_powheg:
+DYto2Tau_MLL_120to200_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Tau_MLL-120to200_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Tau_MLL-200to400_powheg:
+DYto2Tau_MLL_200to400_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Tau_MLL-200to400_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Tau_MLL-400to800_powheg:
+DYto2Tau_MLL_400to800_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Tau_MLL-400to800_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Tau_MLL-800to1500_powheg:
+DYto2Tau_MLL_800to1500_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Tau_MLL-800to1500_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Tau_MLL-1500to2500_powheg:
+DYto2Tau_MLL_1500to2500_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Tau_MLL-1500to2500_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Tau_MLL-2500to4000_powheg:
+DYto2Tau_MLL_2500to4000_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Tau_MLL-2500to4000_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Tau_MLL-4000to6000_powheg:
+DYto2Tau_MLL_4000to6000_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Tau_MLL-4000to6000_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2Tau_MLL-6000_powheg:
+DYto2Tau_MLL_6000_powheg:
   sampleType: DY
   crossSectionStitch: DYto2Tau_MLL-6000_powheg
   generator: powheg
   miniAOD: /DYto2Tau_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-DYto2TautoMuTauh_M-50_madgraphMLM:
+DYto2TautoMuTauh_M_50_madgraphMLM:
   sampleType: DY
   crossSectionStitch: DYto2TautoMuTauh_M-50_madgraphMLM
   generator: madgraphMLM
@@ -370,97 +389,97 @@ QCD_HT2000toInf_MLM:
   crossSection: QCD_HT2000toInf_MLM
   generator: madgraphMLM
   miniAOD: /QCD-4Jets_HT-2000_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-10to30_EMEnriched:
+QCD_PT_10to30_EMEnriched:
   sampleType: QCD
   crossSection: QCD_PT-10to30_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-10to30_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-15to20_MuEnrichedPt5:
+QCD_PT_15to20_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-15to20_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-15to20_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-20to30_MuEnrichedPt5:
+QCD_PT_20to30_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-20to30_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-20to30_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-30to50_EMEnriched:
+QCD_PT_30to50_EMEnriched:
   sampleType: QCD
   crossSection: QCD_PT-30to50_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-30to50_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-30to50_MuEnrichedPt5:
+QCD_PT_30to50_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-30to50_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-30to50_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-50to80_EMEnriched:
+QCD_PT_50to80_EMEnriched:
   sampleType: QCD
   crossSection: QCD_PT-50to80_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-50to80_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-50to80_MuEnrichedPt5:
+QCD_PT_50to80_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-50to80_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-50to80_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-80to120_EMEnriched:
+QCD_PT_80to120_EMEnriched:
   sampleType: QCD
   crossSection: QCD_PT-80to120_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-80to120_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-80to120_MuEnrichedPt5:
+QCD_PT_80to120_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-80to120_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-80to120_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-120to170_EMEnriched:
+QCD_PT_120to170_EMEnriched:
   sampleType: QCD
   crossSection: QCD_PT-120to170_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-120to170_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-120to170_MuEnrichedPt5:
+QCD_PT_120to170_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-120to170_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-120to170_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-170to300_EMEnriched:
+QCD_PT_170to300_EMEnriched:
   sampleType: QCD
   crossSection: QCD_PT-170to300_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-170to300_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-170to300_MuEnrichedPt5:
+QCD_PT_170to300_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-170to300_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-170to300_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-300_EMEnriched:
+QCD_PT_300_EMEnriched:
   sampleType: QCD
   crossSection: QCD_PT-300_EMEnriched
   generator: pythia8
   miniAOD: /QCD_PT-300_EMEnriched_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-300to470_MuEnrichedPt5:
+QCD_PT_300to470_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-300to470_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-300to470_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-470to600_MuEnrichedPt5:
+QCD_PT_470to600_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-470to600_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-470to600_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-600to800_MuEnrichedPt5:
+QCD_PT_600to800_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-600to800_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-600to800_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-800to1000_MuEnrichedPt5:
+QCD_PT_800to1000_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-800to1000_MuEnrichedPt5
   generator: pythia8
   miniAOD: /QCD_PT-800to1000_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-QCD_PT-1000_MuEnrichedPt5:
+QCD_PT_1000_MuEnrichedPt5:
   sampleType: QCD
   crossSection: QCD_PT-1000_MuEnrichedPt5
   generator: pythia8
@@ -542,22 +561,22 @@ QCD_PT_3200:
   miniAOD: /QCD_PT-3200_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM
 
 ############## ST ##############
-ST_s-channel_antitop_4f_leptonDecays:
+ST_s_channel_antitop_4f_leptonDecays:
   sampleType: ST
   crossSection: ST_s-channel_antitop_LNu
   generator: amcatnlo
   miniAOD: /TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_s-channel_top_4f_leptonDecays:
+ST_s_channel_top_4f_leptonDecays:
   sampleType: ST
   crossSection: ST_s-channel_top_LNu
   generator: amcatnlo
   miniAOD: /TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_t-channel_antitop_4f_InclusiveDecays:
+ST_t_channel_antitop_4f_InclusiveDecays:
   sampleType: ST
   crossSection: ST_t-channel_antitop
   generator: powheg
   miniAOD: /TbarBQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_t-channel_top_4f_InclusiveDecays:
+ST_t_channel_top_4f_InclusiveDecays:
   sampleType: ST
   crossSection: ST_t-channel_top
   generator: powheg
@@ -794,16 +813,72 @@ WtoLNu_MLNu-0to120_HT-1500To2500_madgraph:
   crossSection: WtoLNu_MLNu-0to120_HT-1500To2500_madgraph
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_MLNu-0to120_HT-1500to2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-WToMuNu_M-200:
+WToMuNu_M_200:
   sampleType: W
   crossSection: WToMuNu_M-200
   generator: pythia8
   miniAOD: /WtoMuNu_M-200_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-WToTauNu_M-200:
+WToTauNu_M_200:
   sampleType: W
   crossSection: WToTauNu_M-200
   generator: pythia8
   miniAOD: /WtoNuTau_M-200_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
+
+WminusHToTauTau_UncorrelatedDecay_Filtered:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
+WminusHToTauTau_UncorrelatedDecay_UnFiltered:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
+WplusHToTauTau_UncorrelatedDecay_Filtered:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
+WplusHToTauTau_UncorrelatedDecay_UnFiltered:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
+WtoLNu_MLNu_0to120_HT_100To400_madgraph:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
+WtoLNu_MLNu_0to120_HT_1500To2500_madgraph:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
+WtoLNu_MLNu_0to120_HT_400To800_madgraph:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
+WtoLNu_MLNu_0to120_HT_40To100_madgraph:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
+WtoLNu_MLNu_0to120_HT_800To1500_madgraph:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
+ZHToTauTau_UncorrelatedDecay_Filtered:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
+ZHToTauTau_UncorrelatedDecay_UnFiltered:
+  sampleType: W
+  crossSection: fill_me
+  generator: fill_me
+  miniAOD: fill_me
 
 ############## VV ##############
 WW:
@@ -974,54 +1049,54 @@ WZZ:
   miniAOD: /WZZ_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
 
 ############## Zto2Nu ##############
-Zto2Nu_HT-100To200:
+Zto2Nu_HT_100To200:
   sampleType: Zto2Nu
   crossSection: Zto2Nu_HT-100To200
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-Zto2Nu_HT-200To400:
+Zto2Nu_HT_200To400:
   sampleType: Zto2Nu
   crossSection: Zto2Nu_HT-200To400
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-Zto2Nu_HT-400To800:
+Zto2Nu_HT_400To800:
   sampleType: Zto2Nu
   crossSection: Zto2Nu_HT-400To800
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-400to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-Zto2Nu_HT-800To1500:
+Zto2Nu_HT_800To1500:
   sampleType: Zto2Nu
   crossSection: Zto2Nu_HT-800To1500
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-800to1500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v1/MINIAODSIM
-Zto2Nu_HT-1500To2500:
+Zto2Nu_HT_1500To2500:
   sampleType: Zto2Nu
   crossSection: Zto2Nu_HT-1500To2500
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-1500to2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-Zto2Nu_HT-2500ToInf:
+Zto2Nu_HT_2500ToInf:
   sampleType: Zto2Nu
   crossSection: Zto2Nu_HT-2500ToInf
   generator: madgraphMLM
   miniAOD: /Zto2Nu-4Jets_HT-2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
 
 ############## ZQQ ##############
-Zto2Q_HT-200to400:
+Zto2Q_HT_200to400:
   sampleType: ZQQ
   crossSection: Zto2Q_HT-200to400
   generator: madgraphMLM
   miniAOD: /Zto2Q-4Jets_HT-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-Zto2Q_HT-400to600:
+Zto2Q_HT_400to600:
   sampleType: ZQQ
   crossSection: Zto2Q_HT-400to600
   generator: madgraphMLM
   miniAOD: /Zto2Q-4Jets_HT-400to600_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-Zto2Q_HT-600to800:
+Zto2Q_HT_600to800:
   sampleType: ZQQ
   crossSection: Zto2Q_HT-600to800
   generator: madgraphMLM
   miniAOD: /Zto2Q-4Jets_HT-600to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-Zto2Q_HT-800toInf:
+Zto2Q_HT_800toInf:
   sampleType: ZQQ
   crossSection: Zto2Q_HT-800toInf
   generator: madgraphMLM

--- a/config/Run3_2022EE/samples.yaml
+++ b/config/Run3_2022EE/samples.yaml
@@ -147,7 +147,7 @@ DYto2L_M_50_amcatnloFXFX_ext1:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_amcatnloFXFX
   generator: amcatnloFXFX
-  miniAOD: fill_me
+  miniAOD: /DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext2-v2/MINIAODSIM
 
 
 
@@ -207,12 +207,12 @@ DYto2L_M_50_PTLL_600_1J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_PTLL-600_1J_amcatnloFXFX
   generator: amcatnloFXFX
-  miniAOD: fill_me
+  miniAOD: /DYto2L-2Jets_MLL-50_PTLL-600_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM
 DYto2L_M_50_PTLL_600_2J_amcatnloFXFX:
   sampleType: DY
   crossSectionStitch: DYto2L_M-50_PTLL-600_2J_amcatnloFXFX
   generator: amcatnloFXFX
-  miniAOD: fill_me
+  miniAOD: /DYto2L-2Jets_MLL-50_PTLL-600_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v1/MINIAODSIM
 
 DYto2Mu_MLL_10to50_powheg:
   sampleType: DY
@@ -827,58 +827,33 @@ WToTauNu_M_200:
 WminusHToTauTau_UncorrelatedDecay_Filtered:
   sampleType: W
   crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
+  generator: powheg
+  miniAOD: /WminusHTo2TauUncorrelatedDecay_Filtered_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
 WminusHToTauTau_UncorrelatedDecay_UnFiltered:
   sampleType: W
   crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
+  generator: powheg
+  miniAOD: /WminusHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
 WplusHToTauTau_UncorrelatedDecay_Filtered:
   sampleType: W
   crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
+  generator: powheg
+  miniAOD: /WplusHTo2TauUncorrelatedDecay_Filtered_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
 WplusHToTauTau_UncorrelatedDecay_UnFiltered:
   sampleType: W
   crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
-WtoLNu_MLNu_0to120_HT_100To400_madgraph:
-  sampleType: W
-  crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
-WtoLNu_MLNu_0to120_HT_1500To2500_madgraph:
-  sampleType: W
-  crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
-WtoLNu_MLNu_0to120_HT_400To800_madgraph:
-  sampleType: W
-  crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
-WtoLNu_MLNu_0to120_HT_40To100_madgraph:
-  sampleType: W
-  crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
-WtoLNu_MLNu_0to120_HT_800To1500_madgraph:
-  sampleType: W
-  crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
+  generator: powheg
+  miniAOD: /WplusHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
 ZHToTauTau_UncorrelatedDecay_Filtered:
   sampleType: W
   crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
+  generator: powheg
+  miniAOD: /ZHto2TauUncorrelatedDecay_Filtered_M-125_CP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
 ZHToTauTau_UncorrelatedDecay_UnFiltered:
   sampleType: W
   crossSection: fill_me
-  generator: fill_me
-  miniAOD: fill_me
+  generator: powheg
+  miniAOD: /ZHto2TauUncorrelatedDecay_M-125_CP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_20
 
 ############## VV ##############
 WW:

--- a/config/Run3_2022EE/samples.yaml
+++ b/config/Run3_2022EE/samples.yaml
@@ -788,27 +788,27 @@ WtoLNu_madgraphMLM_ext1:
   crossSection: WtoLNu_NNLO_QCD+NLO_EW
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM
-WtoLNu_MLNu-0to120_HT-40To100_madgraph:
+WtoLNu_MLNu_0to120_HT_40To100_madgraph:
   sampleType: W
   crossSection: WtoLNu_MLNu-0to120_HT-40To100_madgraph
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_MLNu-0to120_HT-40to100_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM
-WtoLNu_MLNu-0to120_HT-100To400_madgraph:
+WtoLNu_MLNu_0to120_HT_100To400_madgraph:
   sampleType: W
   crossSection: WtoLNu_MLNu-0to120_HT-100To400_madgraph
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_MLNu-0to120_HT-100to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM
-WtoLNu_MLNu-0to120_HT-400To800_madgraph:
+WtoLNu_MLNu_0to120_HT_400To800_madgraph:
   sampleType: W
   crossSection: WtoLNu_MLNu-0to120_HT-400To800_madgraph
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_MLNu-0to120_HT-400to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM
-WtoLNu_MLNu-0to120_HT-800To1500_madgraph:
+WtoLNu_MLNu_0to120_HT_800To1500_madgraph:
   sampleType: W
   crossSection: WtoLNu_MLNu-0to120_HT-800To1500_madgraph
   generator: madgraphMLM
   miniAOD: /WtoLNu-4Jets_MLNu-0to120_HT-800to1500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-WtoLNu_MLNu-0to120_HT-1500To2500_madgraph:
+WtoLNu_MLNu_0to120_HT_1500To2500_madgraph:
   sampleType: W
   crossSection: WtoLNu_MLNu-0to120_HT-1500To2500_madgraph
   generator: madgraphMLM


### PR DESCRIPTION
Run 3 2022 dataset names are updated.
The current PR only includes the existing skim v1 sample name updates for skim v2. The additional skim v2 samples will be added to this PR.

Run 3 2022EE will be added to this PR later.